### PR TITLE
feat: Implement interactive web UI for IPL auction simulator

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 import game_logic
 import traceback
 import random
-import datetime # For timestamps
+# import datetime # For timestamps - No longer needed here, AuctionManager handles its own timestamps
 
 app = Flask(__name__)
 app.secret_key = os.urandom(24)
@@ -20,6 +20,115 @@ TEAMS_DISPLAY_DATA = {
     "SRH": {"id": "srh", "logo": "SRH.png", "color": "#F27024", "secondary_color": "#1B1920", "name": "Sunrisers Hyderabad"},
     "PBKS": {"id": "pbks", "logo": "PBKS.png", "color": "#DD1F2D", "secondary_color": "#FFFFFF", "name": "Punjab Kings"}
 }
+
+# --- AuctionManager Helper Functions ---
+def _get_auction_manager_instance_from_session():
+    """
+    Initializes or rehydrates an AuctionManager instance using data from the session.
+    It ensures that the Team objects within the AuctionManager are consistent
+    with the latest state stored in session['teams_current_state'].
+    """
+    initial_pool = session.get('initial_auction_pool')
+    initial_teams_json = session.get('initial_teams_json_data')
+    teams_current_state = session.get('teams_current_state') # This is dict form of teams
+    auction_manager_session_state = session.get('auction_manager_state')
+
+    if not initial_pool or not initial_teams_json or not teams_current_state:
+        # This indicates a problem, possibly session cleared or first time error
+        # print("Error: Missing critical data in session for AuctionManager rehydration.")
+        return None # Or raise an exception
+
+    # 1. Create a base AuctionManager instance (this also creates its internal Team objects)
+    auction_manager = game_logic.AuctionManager(initial_pool, initial_teams_json)
+
+    # 2. Synchronize AuctionManager's internal Team objects with teams_current_state from session
+    #    This is similar to part of setup_auction_stage, ensuring budgets and squads are current.
+    for team_id_key, team_data_from_session in teams_current_state.items():
+        team_obj_in_manager = auction_manager.teams.get(team_id_key.upper())
+        if team_obj_in_manager:
+            team_obj_in_manager.budget = team_data_from_session.get('budget', team_obj_in_manager.budget)
+
+            # Reconstruct squad for the Team object based on names and prices in session state
+            rehydrated_squad = []
+            player_names_in_session_squad = team_data_from_session.get('squad_after_retention', [])
+            player_prices_in_session = team_data_from_session.get('player_prices', {})
+
+            for p_name in player_names_in_session_squad:
+                p_detail = next((p.copy() for p in initial_pool if p['name'] == p_name), None)
+                if p_detail:
+                    price = player_prices_in_session.get(p_name, 0) # Default price to 0 if not found
+                    p_detail['Price'] = price
+                    rehydrated_squad.append(p_detail)
+            team_obj_in_manager.squad = rehydrated_squad
+        else:
+            # print(f"Warning: Team {team_id_key} from teams_current_state not found in AuctionManager internal teams during rehydration.")
+            pass
+
+
+    # 3. Apply saved AuctionManager state (if it exists)
+    if auction_manager_session_state:
+        auction_manager.current_auction_pool_for_bidding = auction_manager_session_state.get('current_auction_pool_for_bidding', [])
+        auction_manager.sold_players_log = auction_manager_session_state.get('sold_players_log', [])
+        auction_manager.unsold_players_log = auction_manager_session_state.get('unsold_players_log', [])
+        auction_manager.current_player_auction_index = auction_manager_session_state.get('current_player_auction_index', -1)
+        auction_manager.current_player_up_for_auction = auction_manager_session_state.get('current_player_up_for_auction', None)
+        auction_manager.current_bids_log_for_player = auction_manager_session_state.get('current_bids_log_for_player', [])
+        auction_manager.current_highest_bid_amount = auction_manager_session_state.get('current_highest_bid_amount', 0)
+
+        highest_bidder_team_name = auction_manager_session_state.get('current_highest_bidder_team_name')
+        if highest_bidder_team_name:
+            auction_manager.current_highest_bidder_team_obj = auction_manager.get_team_object_by_name(highest_bidder_team_name)
+        else:
+            auction_manager.current_highest_bidder_team_obj = None
+        # auction_over_flag is derived by is_auction_over() method or start_bidding_for_next_player result
+
+    return auction_manager
+
+def _save_auction_state_to_session(auction_manager):
+    """
+    Saves the operational state of the AuctionManager and the state of its Team objects
+    back into the Flask session.
+    """
+    if not auction_manager:
+        # print("Error: No AuctionManager instance provided to save_auction_state.")
+        return
+
+    # 1. Extract serializable state from AuctionManager
+    auction_manager_serializable_state = {
+        'current_auction_pool_for_bidding': auction_manager.current_auction_pool_for_bidding,
+        'sold_players_log': auction_manager.sold_players_log,
+        'unsold_players_log': auction_manager.unsold_players_log,
+        'current_player_auction_index': auction_manager.current_player_auction_index,
+        'current_player_up_for_auction': auction_manager.current_player_up_for_auction, # Assumed to be a dict
+        'current_bids_log_for_player': auction_manager.current_bids_log_for_player, # Assumed to be list of dicts
+        'current_highest_bid_amount': auction_manager.current_highest_bid_amount,
+        'current_highest_bidder_team_name': auction_manager.current_highest_bidder_team_obj.name if auction_manager.current_highest_bidder_team_obj else None,
+        # auction_over_flag is not explicitly stored here, derived by logic in auction_main
+    }
+    session['auction_manager_state'] = auction_manager_serializable_state
+
+    # 2. Update session['teams_current_state'] from AuctionManager's internal Team objects
+    # This is crucial because AuctionManager's Team objects are modified during auction (e.g. budget, squad)
+    teams_current_state_updated = session.get('teams_current_state', {})
+    for team_id_key, team_obj_in_manager in auction_manager.teams.items():
+        if team_id_key.lower() in teams_current_state_updated: # Ensure case consistency, session uses lowercase id
+            teams_current_state_updated[team_id_key.lower()]['budget'] = team_obj_in_manager.budget
+            teams_current_state_updated[team_id_key.lower()]['squad_after_retention'] = [p['name'] for p in team_obj_in_manager.squad]
+
+            # Update player_prices within teams_current_state
+            current_prices = teams_current_state_updated[team_id_key.lower()].get('player_prices', {})
+            for player_in_squad in team_obj_in_manager.squad:
+                current_prices[player_in_squad['name']] = player_in_squad.get('Price', 0) # Price is set in Team.add_player_to_squad
+            teams_current_state_updated[team_id_key.lower()]['player_prices'] = current_prices
+        else:
+            # print(f"Warning: Team {team_id_key} from AuctionManager not found in session's teams_current_state during save.")
+            pass
+
+    session['teams_current_state'] = teams_current_state_updated
+    session.modified = True # Ensure session changes are saved
+
+# --- End AuctionManager Helper Functions ---
+
 
 @app.route('/')
 def index():
@@ -163,152 +272,259 @@ def process_retention_choices():
     session['auction_pool_available_for_auction'] = auction_pool_after_retention
     session['auction_runtime_state'] = {'current_player_index': -1} # Initialize for auction page
 
-    return redirect(url_for('auction_main'))
+    return redirect(url_for('retention_summary'))
+
+@app.route('/retention_summary')
+def retention_summary():
+    user_team_id = session.get('user_team_id')
+    user_team_display_info = session.get('user_team_display_info')
+    teams_current_state = session.get('teams_current_state')
+    initial_auction_pool = session.get('initial_auction_pool')
+
+    if not all([user_team_id, user_team_display_info, teams_current_state, initial_auction_pool]):
+        # Redirect to home or an error page if essential data is missing
+        return redirect(url_for('index'))
+
+    # Convert player names in squad_after_retention to full player objects for the template
+    # The template expects player objects with 'id', 'name', 'role'
+    # teams_current_state has squad_after_retention as list of names.
+    # initial_auction_pool has full player details but uses 'name' not 'id' for matching in this context.
+
+    processed_teams_current_state = {}
+    for team_id, team_data in teams_current_state.items():
+        processed_team_data = team_data.copy()
+        retained_player_details_list = []
+        for player_name in team_data.get('squad_after_retention', []):
+            player_obj = get_player_details_from_pool(player_name, initial_auction_pool)
+            if player_obj:
+                 # The template uses 'id' from the player object, ensure it's there.
+                 # The price is fixed at 150L for retained players as per requirement.
+                retained_player_details_list.append(player_obj)
+        processed_team_data['players_details'] = retained_player_details_list # Use this new key in template
+        processed_teams_current_state[team_id] = processed_team_data
+
+    # The user_team_display_info already has an 'id' field ('csk', 'mi' etc)
+    # The template also expects this 'id' to correctly identify the user's team within processed_teams_current_state
+
+    return render_template('retention_summary.html',
+                           user_team_display_info=user_team_display_info, # Contains user team 'id' and 'name'
+                           teams_current_state=processed_teams_current_state, # Contains all teams, with 'players_details'
+                           initial_auction_pool=initial_auction_pool) # For player lookups if any (though ideally pre-processed)
+
 
 def get_player_details_from_pool(player_name, auction_pool_list):
     return next((p for p in auction_pool_list if p['name'] == player_name), None)
 
-def initialize_auction_turn_state_for_new_player(player_obj):
-    return {
-        "bids_log": [{"bidder": "System", "info": f"Auction for {player_obj['name']} (Base: ₹{player_obj['base_price']}L)", "timestamp": datetime.datetime.now().strftime("%H:%M:%S")}],
-        "current_highest_bid": player_obj['base_price'],
-        "current_highest_bidder_id": None,
-        "player_sold_status_message": None
-    }
+# initialize_auction_turn_state_for_new_player function is removed as AuctionManager.start_bidding_for_next_player
+# now handles the initialization of bid logs including the initial system message with timestamp.
 
 @app.route('/auction')
 def auction_main():
     user_team_id = session.get('user_team_id')
     if not user_team_id: return redirect(url_for('index'))
 
-    teams_all_current_state = session.get('teams_current_state', {})
-    user_team_current_data = teams_all_current_state.get(user_team_id, {})
-    auction_pool = session.get('auction_pool_available_for_auction', [])
-    auction_runtime_state = session.get('auction_runtime_state', {})
-    current_player_index = auction_runtime_state.get('current_player_index', -1)
+    # Initialize AuctionManager on first visit after retention or if session is new
+    if 'auction_manager_state' not in session:
+        initial_pool = session.get('initial_auction_pool')
+        initial_teams_json = session.get('initial_teams_json_data')
+        teams_state_after_retention = session.get('teams_current_state')
+        auction_pool_after_retention = session.get('auction_pool_available_for_auction')
 
-    current_player_object_from_session = auction_runtime_state.get('player_up_for_auction')
-    is_player_active_and_unsold = current_player_object_from_session and not auction_runtime_state.get('player_sold_status_message')
+        if not all([initial_pool, initial_teams_json, teams_state_after_retention, auction_pool_after_retention]):
+            # print("Error: Missing data for initial AuctionManager setup.")
+            return redirect(url_for('index')) # Or an error page
 
-    if not is_player_active_and_unsold:
-        current_player_index += 1
-        if current_player_index < len(auction_pool):
-            next_player_obj_for_auction = auction_pool[current_player_index]
-            turn_init_state = initialize_auction_turn_state_for_new_player(next_player_obj_for_auction)
-            auction_runtime_state.update({
-                'current_player_index': current_player_index,
-                'player_up_for_auction': next_player_obj_for_auction,
-                **turn_init_state
-            })
-            session['auction_runtime_state'] = auction_runtime_state
-        else: # Auction ends
-            session['auction_runtime_state']['auction_over_message'] = "All players auctioned!"
-            session['auction_runtime_state'] = auction_runtime_state # Save state before redirect
+        auction_manager = game_logic.AuctionManager(initial_pool, initial_teams_json)
+        auction_manager.setup_auction_stage(teams_state_after_retention, auction_pool_after_retention)
+        # Initial save to populate session['auction_manager_state'] and sync teams_current_state
+        _save_auction_state_to_session(auction_manager)
+
+    # Get (potentially rehydrated) AuctionManager instance
+    auction_manager = _get_auction_manager_instance_from_session()
+    if not auction_manager:
+        # print("Error: Could not get AuctionManager instance.")
+        return redirect(url_for('index')) # Or an error page
+
+    # Check if auction is over
+    if auction_manager.is_auction_over():
+        # Ensure any final state is saved before redirecting
+        _save_auction_state_to_session(auction_manager)
+        return redirect(url_for('auction_summary_page'))
+
+    # If no player is up for auction (and auction not over), start bidding for the next one
+    if auction_manager.current_player_up_for_auction is None:
+        _player_obj, _highest_bid, auction_just_ended = auction_manager.start_bidding_for_next_player()
+        _save_auction_state_to_session(auction_manager) # Save state after fetching next player
+        if auction_just_ended:
             return redirect(url_for('auction_summary_page'))
+        # If a new player was fetched, auction_manager instance is updated, re-fetch for local vars if needed for immediate use
+        # Though for rendering, the updated auction_manager from _get_auction_manager_instance_from_session on next request, or direct use, is fine.
+        # No, we need to use the current auction_manager instance that was just updated.
 
-    # Refresh player_to_auction after potential update
-    player_to_auction = auction_runtime_state.get('player_up_for_auction')
-    if not player_to_auction: # Should be caught by redirect above, but as a safeguard
-         return redirect(url_for('auction_summary_page'))
+    # Ensure we have the latest teams_current_state for display (user team budget etc.)
+    # _get_auction_manager_instance_from_session would have synced AM.teams based on session's teams_current_state
+    # But if AM operations modified teams (not in this GET route, but good practice), then _save_auction_state_to_session
+    # would have updated session's teams_current_state. For display, we read fresh from session.
+    teams_all_current_state_display = session.get('teams_current_state', {})
+    user_team_current_data_display = teams_all_current_state_display.get(user_team_id, {})
 
-    current_highest_bidder_name = "None"
-    highest_bidder_id_from_session = auction_runtime_state.get('current_highest_bidder_id')
-    if highest_bidder_id_from_session: # This ID is 'csk', 'mi' etc.
-        # Use TEAMS_DISPLAY_DATA for full name, it expects uppercase keys like "CSK"
-        bidder_display_info = TEAMS_DISPLAY_DATA.get(highest_bidder_id_from_session.upper())
-        current_highest_bidder_name = bidder_display_info['name'] if bidder_display_info else highest_bidder_id_from_session.upper()
 
-    all_teams_budgets_display = [{
+    current_highest_bidder_name_display = "None"
+    if auction_manager.current_highest_bidder_team_obj:
+        bidder_display_key = auction_manager.current_highest_bidder_team_obj.name.upper() # e.g. "CSK"
+        bidder_display_info = TEAMS_DISPLAY_DATA.get(bidder_display_key)
+        current_highest_bidder_name_display = bidder_display_info['name'] if bidder_display_info else bidder_display_key
+
+
+    all_teams_budgets_display_info = [{
         "name": TEAMS_DISPLAY_DATA.get(team_id_key.upper(), {}).get('name', team_id_key.upper()),
         "budget": team_data_val.get('budget'),
         "squad_count": len(team_data_val.get('squad_after_retention', []))
-    } for team_id_key, team_data_val in teams_all_current_state.items()]
+    } for team_id_key, team_data_val in teams_all_current_state_display.items()]
 
-    user_squad_names = user_team_current_data.get('squad_after_retention', [])
-    initial_pool_for_details = session.get('initial_auction_pool', [])
-    player_prices_for_user_team = teams_all_current_state.get(user_team_id, {}).get('player_prices', {})
-    user_squad_full_details = []
-    for name in user_squad_names:
-        player_obj_detail = get_player_details_from_pool(name, initial_pool_for_details) # Get base details
+    user_squad_names_display = user_team_current_data_display.get('squad_after_retention', [])
+    initial_pool_for_details_display = session.get('initial_auction_pool', []) # For roles, base stats etc.
+    player_prices_for_user_team_display = user_team_current_data_display.get('player_prices', {})
+    user_squad_full_details_display = []
+    for name in user_squad_names_display:
+        player_obj_detail = get_player_details_from_pool(name, initial_pool_for_details_display)
         if player_obj_detail:
-             price = player_prices_for_user_team.get(name, "Retained")
+             price = player_prices_for_user_team_display.get(name, "Retained")
              display_price_str = f"₹{price}L" if isinstance(price, (int, float)) else price
-             user_squad_full_details.append({**player_obj_detail, "display_price": display_price_str})
+             user_squad_full_details_display.append({**player_obj_detail, "display_price": display_price_str})
 
+    # Data for the template directly from auction_manager state
+    # No need for the old auction_runtime_state anymore
     return render_template('auction.html',
                            user_team_display_name=TEAMS_DISPLAY_DATA.get(user_team_id.upper(),{}).get('name','Your Team'),
-                           user_team_current_budget=user_team_current_data.get('budget'),
-                           user_team_max_squad=user_team_current_data.get('max_squad_size', 18),
-                           user_squad_display=user_squad_full_details,
-                           auction_runtime_state_snapshot=auction_runtime_state,
-                           current_highest_bidder_display_name=current_highest_bidder_name,
-                           all_teams_budgets_info=all_teams_budgets_display,
-                           total_players_in_auction_pool=len(auction_pool),
-                           current_player_auction_number=auction_runtime_state.get('current_player_index', -1) + 1)
+                           user_team_current_budget=user_team_current_data_display.get('budget'),
+                           user_team_max_squad=user_team_current_data_display.get('max_squad_size', 18), # This might be from rules or team obj
+                           user_squad_display=user_squad_full_details_display,
+
+                           # Data from AuctionManager
+                           current_player_for_auction=auction_manager.current_player_up_for_auction, # dict
+                           bids_log=auction_manager.current_bids_log_for_player, # list of dicts
+                           current_highest_bid=auction_manager.current_highest_bid_amount, # number
+                           current_highest_bidder_display_name=current_highest_bidder_name_display, # string
+
+                           all_teams_budgets_info=all_teams_budgets_display_info,
+                           total_players_in_auction_pool=len(auction_manager.current_auction_pool_for_bidding),
+                           current_player_auction_number=auction_manager.current_player_auction_index + 1,
+                           auction_over=auction_manager.is_auction_over() # Pass auction over flag
+                           )
 
 @app.route('/auction/summary')
 def auction_summary_page():
     teams_final_state = session.get('teams_current_state', {})
-    sold_players_history = session.get('sold_players_history', [])
+
+    # Get auction results from AuctionManager's state
+    auction_manager_state = session.get('auction_manager_state', {})
+    sold_players_log = auction_manager_state.get('sold_players_log', [])
+    unsold_players_log = auction_manager_state.get('unsold_players_log', []) # Potentially display this too
+
+    # The sold_players_log from AuctionManager already contains:
+    # {"name": player_name, "price": final_price, "team_id": winning_team_obj.name, "role": player_role}
+    # We can augment teams_final_state with display names if needed, but player details are mostly in sold_players_log
 
     for team_id, team_data in teams_final_state.items():
         team_data['player_price_details'] = []
-        player_prices = team_data.get('player_prices', {})
-        for player_name in team_data.get('squad_after_retention', []):
-             price = player_prices.get(player_name, "Retained") # Default if price somehow not set
-             price_str = f"₹{price}L" if isinstance(price, (int, float)) else str(price)
-             # Get player role from initial_auction_pool for display
-             player_role = "N/A"
-             initial_pool = session.get('initial_auction_pool', [])
-             player_detail = get_player_details_from_pool(player_name, initial_pool)
-             if player_detail: player_role = player_detail.get('role', 'N/A')
-             team_data['player_price_details'].append({"name": player_name, "role": player_role, "price_str": price_str})
-        # Add display name for summary page
+        player_prices = team_data.get('player_prices', {}) # Contains prices for retained and bought players
+        squad_player_names = team_data.get('squad_after_retention', []) # This list contains names of all players in squad
+
+        for player_name in squad_player_names:
+            price = player_prices.get(player_name, "N/A")
+            price_str = f"₹{price}L" if isinstance(price, (int, float)) else str(price)
+
+            player_role = "N/A"
+            # Try to get role from sold_players_log first for auctioned players
+            sold_player_entry = next((p for p in sold_players_log if p['name'] == player_name and p['team_id'].lower() == team_id.lower()), None)
+            if sold_player_entry:
+                player_role = sold_player_entry.get('role', 'N/A')
+            else: # Player might be retained, look up in initial_pool
+                initial_pool = session.get('initial_auction_pool', [])
+                player_detail_from_pool = get_player_details_from_pool(player_name, initial_pool)
+                if player_detail_from_pool:
+                    player_role = player_detail_from_pool.get('role', 'N/A')
+
+            team_data['player_price_details'].append({"name": player_name, "role": player_role, "price_str": price_str})
+
         team_data['display_name'] = TEAMS_DISPLAY_DATA.get(team_id.upper(), {}).get('name', team_id.upper())
 
-
-    return render_template('summary.html', teams_final_state_display=teams_final_state, sold_players_history_display=sold_players_history)
+    # Pass the consolidated sold_players_log to the template.
+    # The template might need adjustment if it was relying on a different structure for sold_players_history.
+    return render_template('summary.html',
+                           teams_final_state_display=teams_final_state,
+                           sold_players_summary_display=sold_players_log, # New name for clarity
+                           unsold_players_summary_display=unsold_players_log) # Optional: for display
 
 @app.route('/auction/bid', methods=['POST'])
 def auction_bid():
-    # To be fully implemented in Step 8
+    user_team_id = session.get('user_team_id')
+    if not user_team_id:
+        return redirect(url_for('index'))
+
+    bid_amount_str = request.form.get('bid_amount')
+    if not bid_amount_str:
+        # flash("Bid amount is required.", "error") # Optional: add flash messaging
+        return redirect(url_for('auction_main'))
+
+    try:
+        bid_amount = int(bid_amount_str)
+    except ValueError:
+        # flash("Invalid bid amount.", "error")
+        return redirect(url_for('auction_main'))
+
+    auction_manager = _get_auction_manager_instance_from_session()
+    if not auction_manager or auction_manager.is_auction_over() or not auction_manager.current_player_up_for_auction:
+        # flash("Auction is over or no player is currently up for bidding.", "warning")
+        return redirect(url_for('auction_main'))
+
+    user_team_obj = auction_manager.get_team_object_by_name(user_team_id)
+    if not user_team_obj:
+        # flash("User team data not found.", "error")
+        return redirect(url_for('index'))
+
+    bid_successful, message = auction_manager.process_user_bid(user_team_obj, bid_amount)
+    # flash(message, "success" if bid_successful else "error") # Optional
+
+    if bid_successful:
+        # Trigger AI bids only if user bid was successful
+        _ai_winner_obj, ai_message = auction_manager.trigger_ai_bids_after_user_action(user_team_obj.name)
+        # flash(ai_message, "info") # Optional for AI bidding updates
+
+    _save_auction_state_to_session(auction_manager)
     return redirect(url_for('auction_main'))
 
-@app.route('/auction/observe', methods=['POST'])
-def auction_observe():
-    # To be fully implemented in Step 8
+@app.route('/auction_finalize_player', methods=['POST'])
+def auction_finalize_player():
+    user_team_id = session.get('user_team_id')
+    if not user_team_id:
+        return redirect(url_for('index'))
+
+    auction_manager = _get_auction_manager_instance_from_session()
+    if not auction_manager or not auction_manager.current_player_up_for_auction:
+        # flash("No player auction to finalize or auction manager not found.", "warning")
+        # If auction is over, is_auction_over() check in auction_main will redirect to summary.
+        # This route is mainly if a player is active.
+        return redirect(url_for('auction_main'))
+
+    # Finalize the current player (sell or mark as unsold)
+    # This method updates team squads/budgets within AuctionManager's Team objects
+    # and logs the player as sold/unsold.
+    # It also sets current_player_up_for_auction to None.
+    _sold, message, _winning_team_id, _auction_now_over = auction_manager.finalize_current_player_auction()
+    # flash(message, "info") # Optional
+
+    # Save changes to AuctionManager state and teams_current_state (which reflects budget/squad changes)
+    _save_auction_state_to_session(auction_manager)
+
+    # Redirecting to auction_main will then pick the next player or go to summary if auction ended
     return redirect(url_for('auction_main'))
 
-@app.route('/auction/skip', methods=['POST'])
-def auction_skip():
-    auction_runtime_state = session.get('auction_runtime_state', {})
-    current_player_obj = auction_runtime_state.get('player_up_for_auction')
-    if current_player_obj:
-        # Mark player as unsold/skipped for this turn
-        auction_runtime_state['player_sold_status_message'] = f"{current_player_obj['name']} was SKIPPED by user (UNSOLD for now)."
-
-        # Log this action
-        log_entry = {
-            "bidder": "System",
-            "info": f"Player {current_player_obj['name']} skipped by user. Marked as UNSOLD (pending AI simulation).",
-            "timestamp": datetime.datetime.now().strftime("%H:%M:%S")
-        }
-        if 'bids_log' not in auction_runtime_state or not isinstance(auction_runtime_state['bids_log'], list):
-            auction_runtime_state['bids_log'] = [log_entry]
-        else:
-            auction_runtime_state['bids_log'].append(log_entry)
-
-        # Add to overall sold_players_history as UNSOLD for now
-        sold_players_history = session.get('sold_players_history', [])
-        sold_players_history.append({
-            "name": current_player_obj['name'], "role": current_player_obj.get('role', 'N/A'),
-            "price": 0, "team": "UNSOLD (Skipped)", "reason": "Skipped by User"
-        })
-        session['sold_players_history'] = sold_players_history
-
-        session['auction_runtime_state'] = auction_runtime_state
-
-    return redirect(url_for('auction_main'))
+# Old /auction/observe and /auction/skip routes are now removed as their functionality
+# is covered by the new auction flow:
+# - AI bids are triggered automatically after a user's valid bid.
+# - Finalizing a player (which includes passing) is handled by /auction_finalize_player.
 
 # Test initialization route (can be kept or removed)
 @app.route('/test_initialization/<team_key_for_test>')

--- a/templates/auction.html
+++ b/templates/auction.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>IPL Auction - {{ auction_runtime_state_snapshot.player_up_for_auction.name }}</title>
+    <title>IPL Auction - {% if current_player_for_auction %}{{ current_player_for_auction.name }}{% else %}No Player Selected{% endif %}</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <style>
         .auction-layout { display: flex; justify-content: space-between; margin-top: 20px; }
@@ -12,7 +12,7 @@
         .bid-log p { margin: 2px 0; font-size: 0.9em; }
         .bid-log .system { color: #007bff; font-style: italic; }
         .bid-log .user-bid { color: #28a745; font-weight: bold;}
-        .bid-log .ai-bid { color: #dc3545; }
+        .bid-log .ai-bid { color: #dc3545; } /* This might need actual team name class if we want specific AI team colors */
         .team-budgets { margin-top:15px; }
         .team-budgets table { width:100%; border-collapse: collapse; }
         .team-budgets th, .team-budgets td { border:1px solid #ddd; padding: 4px; text-align: left; font-size:0.85em; }
@@ -21,64 +21,73 @@
         .user-dashboard ul { list-style: none; padding-left: 0;}
         .user-dashboard ul li { margin-bottom: 3px; font-size:0.9em;}
         .player-status-message { padding: 10px; background-color: #ffc107; color: #333; border-radius: 4px; margin-bottom: 15px; text-align: center; font-weight: bold;}
+        .auction-over-message { padding: 10px; background-color: #17a2b8; color: white; text-align: center; font-weight: bold; margin-bottom: 15px;}
     </style>
 </head>
 <body>
     <header>
-        <h1>IPL Auction - Player {{current_player_auction_number}} of {{total_players_in_auction_pool}}</h1>
+        <h1>IPL Auction{% if not auction_over %} - Player {{current_player_auction_number}} of {{total_players_in_auction_pool}}{% else %} Over{% endif %}</h1>
     </header>
 
     <div class="container">
-        {% if auction_runtime_state_snapshot.player_sold_status_message %}
-            <div class="player-status-message">
-                {{ auction_runtime_state_snapshot.player_sold_status_message }}
-                <!-- This message means player is sold/unsold, so primary actions should be to go to next player -->
+        {% if auction_over %}
+            <div class="auction-over-message">
+                The auction is now complete.
+                <p><a href="{{ url_for('auction_summary_page') }}" class="button-like">View Final Auction Summary</a></p>
             </div>
         {% endif %}
 
-        <div class="auction-layout">
-            <div class="player-display">
-                <h2>Up for Auction: {{ auction_runtime_state_snapshot.player_up_for_auction.name }}</h2>
-                <p><strong>Role:</strong> {{ auction_runtime_state_snapshot.player_up_for_auction.role }}</p>
-                <p><strong>Base Price:</strong> ₹{{ auction_runtime_state_snapshot.player_up_for_auction.base_price }}L</p>
-                <p><strong>Demand Score:</strong> {{ auction_runtime_state_snapshot.player_up_for_auction.demand }}</p>
-                <hr>
-                <h4>Stats:</h4>
-                <p>Runs: {{ auction_runtime_state_snapshot.player_up_for_auction.runs }} | Avg: {{ auction_runtime_state_snapshot.player_up_for_auction.avg }} | SR: {{ auction_runtime_state_snapshot.player_up_for_auction.sr }}</p>
-                <p>Wickets: {{ auction_runtime_state_snapshot.player_up_for_auction.wickets }} | Eco: {{ auction_runtime_state_snapshot.player_up_for_auction.eco }}</p>
-            </div>
-
-            <div class="bidding-panel">
-                <h3>Current Highest Bid: ₹{{ auction_runtime_state_snapshot.current_highest_bid }}L</h3>
-                <p><strong>Highest Bidder:</strong> <span id="highestBidderName">{{ current_highest_bidder_display_name }}</span></p>
-
-                <h4>Bid Log:</h4>
-                <div class="bid-log">
-                    {% for bid_entry in auction_runtime_state_snapshot.bids_log %}
-                        <p class="{{ bid_entry.bidder.lower() if bid_entry.bidder != 'System' else 'system' }}">
-                           [{{ bid_entry.timestamp }}] <strong>{{ bid_entry.bidder }}:</strong> {{ bid_entry.info }}
-                        </p>
-                    {% endfor %}
+        {% if current_player_for_auction and not auction_over %}
+            <div class="auction-layout">
+                <div class="player-display">
+                    <h2>Up for Auction: {{ current_player_for_auction.name }}</h2>
+                    <p><strong>Role:</strong> {{ current_player_for_auction.role }}</p>
+                    <p><strong>Base Price:</strong> ₹{{ current_player_for_auction.base_price }}L</p>
+                    <p><strong>Demand Score:</strong> {{ current_player_for_auction.demand }}</p>
+                    <hr>
+                    <h4>Stats:</h4>
+                    <p>Runs: {{ current_player_for_auction.runs }} | Avg: {{ current_player_for_auction.avg }} | SR: {{ current_player_for_auction.sr }}</p>
+                    <p>Wickets: {{ current_player_for_auction.wickets }} | Eco: {{ current_player_for_auction.eco }}</p>
                 </div>
 
-                {% if not auction_runtime_state_snapshot.player_sold_status_message %}
-                <form action="{{ url_for('auction_bid') }}" method="POST" style="display:inline;">
-                    <input type="number" name="bid_amount" placeholder="Your Bid (Lakhs)" min="{{ auction_runtime_state_snapshot.current_highest_bid + 10 }}" step="10" required>
-                    <button type="submit">Place Bid</button>
-                </form>
-                <form action="{{ url_for('auction_observe') }}" method="POST" style="display:inline;">
-                    <button type="submit">Observe AI Bids</button>
-                </form>
-                <form action="{{ url_for('auction_skip') }}" method="POST" style="display:inline;">
-                    <button type="submit" onclick="return confirm('Are you sure you want to skip this player? This might mark them as UNSOLD for you.')">Skip Player</button>
-                </form>
-                {% else %}
-                 <form action="{{ url_for('auction_main') }}" method="GET" style="display:inline;">
-                    <button type="submit">Next Player</button>
-                </form>
-                {% endif %}
+                <div class="bidding-panel">
+                    <h3>Current Highest Bid: ₹{{ current_highest_bid }}L</h3>
+                    <p><strong>Highest Bidder:</strong> <span id="highestBidderName">{{ current_highest_bidder_display_name }}</span></p>
+
+                    <h4>Bid Log:</h4>
+                    <div class="bid-log">
+                        {% for bid_entry in bids_log %}
+                            {# Determine class based on bidder - assumes user team name is available or a generic 'user-bid' #}
+                            {% set bidder_class = 'system' %}
+                            {% if bid_entry.bidder == user_team_display_name %}
+                                {% set bidder_class = 'user-bid' %}
+                            {% elif bid_entry.bidder != 'System' %}
+                                {% set bidder_class = 'ai-bid' %} {# Or more specific if AI team names are used in log #}
+                            {% endif %}
+                            <p class="{{ bidder_class }}">
+                               [{{ bid_entry.timestamp }}] <strong>{{ bid_entry.bidder }}:</strong> {{ bid_entry.info }}
+                            </p>
+                        {% else %}
+                            <p>No bids placed yet for this player.</p>
+                        {% endfor %}
+                    </div>
+
+                    <form action="{{ url_for('auction_bid') }}" method="POST" style="display:inline;">
+                        <input type="number" name="bid_amount" placeholder="Your Bid (Lakhs)" min="{{ current_highest_bid + 10 if current_player_for_auction.base_price == current_highest_bid else current_highest_bid + 10 }}" step="10" required>
+                        <button type="submit">Place Bid</button>
+                    </form>
+
+                    <form action="{{ url_for('auction_finalize_player') }}" method="POST" style="display:inline;">
+                        <button type="submit" onclick="return confirm('Are you sure you want to pass on this player? The player will be sold to the current highest bidder or remain unsold.')">Pass & Finalize Player</button>
+                    </form>
+                </div>
             </div>
-        </div>
+        {% elif not auction_over %}
+            <p>Loading next player for auction...</p>
+             <script>
+                setTimeout(function(){ window.location.reload(); }, 3000); // Auto-refresh if stuck
+            </script>
+        {% endif %}
 
         <div class="user-dashboard">
             <h3>Your Team: {{ user_team_display_name }}</h3>
@@ -107,7 +116,12 @@
             </table>
         </div>
         <hr style="margin-top: 20px;">
-        <p><a href="{{ url_for('index') }}">Quit Auction (Reset Session)</a> | <a href="{{ url_for('auction_summary_page') }}">Go to Auction Summary (Ends Auction)</a></p>
+        <p>
+            <a href="{{ url_for('index') }}">Quit Auction (Reset Session)</a>
+            {% if not auction_over %}
+            | <a href="{{ url_for('auction_summary_page') }}" onclick="return confirm('This will end the current auction and take you to the summary. Are you sure?')">End Auction & Go to Summary</a>
+            {% endif %}
+        </p>
 
     </div>
 </body>

--- a/templates/retention_summary.html
+++ b/templates/retention_summary.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Retention Summary</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div class="container">
+        <h1>Retention Summary</h1>
+
+        <h2>{{ user_team_display_info['name'] }}'s Retentions</h2>
+        <p>Remaining Budget: {{ teams_current_state[user_team_display_info['id']]['budget'] }} L</p>
+        <h3>Retained Players:</h3>
+        <ul>
+            {% for player in teams_current_state[user_team_display_info['id']]['players_details'] %}
+                <li>{{ player.name }} ({{ player.role }}) - 150L</li>
+            {% else %}
+                <li>No players retained.</li>
+            {% endfor %}
+        </ul>
+
+        <hr>
+
+        <h2>Other Teams' Retentions</h2>
+        {% for team_id, team_data in teams_current_state.items() %}
+            {% if team_id != user_team_display_info['id'] %}
+                <h3>{{ team_data.name }}</h3>
+                <p>Remaining Budget: {{ team_data.budget }} L</p>
+                <h4>Retained Players:</h4>
+                <ul>
+                    {% for player in team_data.players_details %}
+                        <li>{{ player.name }} ({{ player.role }}) - 150L</li>
+                    {% else %}
+                        <li>No players retained.</li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        {% endfor %}
+
+        <hr>
+
+        <a href="{{ url_for('auction_main') }}" class="button">Proceed to Auction</a>
+    </div>
+</body>
+</html>

--- a/templates/summary.html
+++ b/templates/summary.html
@@ -8,8 +8,8 @@
         .team-summary-card { border: 1px solid #ddd; padding: 15px; margin-bottom: 15px; background-color: #f9f9f9; border-radius: 5px;}
         .team-summary-card h3 { margin-top: 0; color: #007bff; }
         .player-list li { font-size: 0.9em; }
-        .sold-history table { width: 100%; border-collapse: collapse; margin-top:10px;}
-        .sold-history th, .sold-history td { border: 1px solid #ddd; padding: 6px; text-align: left; font-size:0.9em;}
+        .sold-history table, .unsold-history table { width: 100%; border-collapse: collapse; margin-top:10px;}
+        .sold-history th, .sold-history td, .unsold-history th, .unsold-history td { border: 1px solid #ddd; padding: 6px; text-align: left; font-size:0.9em;}
     </style>
 </head>
 <body>
@@ -23,7 +23,7 @@
         <div class="team-summary-card">
             <h3>{{ team_details.display_name }}</h3>
             <p><strong>Budget Remaining:</strong> ₹{{ team_details.budget }}L</p>
-            <p><strong>Squad Size:</strong> {{ team_details.squad_after_retention | length }} / {{ team_details.max_squad_size }}</p>
+            <p><strong>Squad Size:</strong> {{ team_details.player_price_details | length }} / {{ team_details.max_squad_size }}</p>
             <h4>Squad:</h4>
             <ul class="player-list">
                 {% for player_info in team_details.player_price_details %}
@@ -38,34 +38,59 @@
         {% endfor %}
 
         <h2>Auction Transaction History (Sold Players):</h2>
-        {% if sold_players_history_display %}
+        {% if sold_players_summary_display %}
         <div class="sold-history">
             <table>
                 <thead>
                     <tr>
                         <th>Player Name</th>
                         <th>Role</th>
-                        <th>Sold To</th>
+                        <th>Sold To (Team ID)</th>
                         <th>Price (Lakhs)</th>
-                        <th>Reason (if any)</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for item in sold_players_history_display %}
+                    {% for item in sold_players_summary_display %}
                     <tr>
                         <td>{{ item.name }}</td>
                         <td>{{ item.role }}</td>
-                        <td>{{ item.team }}</td>
+                        <td>{{ item.team_id.upper() if item.team_id else 'N/A' }}</td>
                         <td>₹{{ item.price }}L</td>
-                        <td>{{ item.reason | default('') }}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
         </div>
         {% else %}
-            <p>No players were sold in this auction or history is unavailable.</p>
+            <p>No players were sold in this auction.</p>
         {% endif %}
+
+        <h2>Unsold Players:</h2>
+        {% if unsold_players_summary_display %}
+        <div class="unsold-history">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Player Name</th>
+                        <th>Role</th>
+                        <th>Base Price (Lakhs)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for player in unsold_players_summary_display %}
+                    <tr>
+                        <td>{{ player.name }}</td>
+                        <td>{{ player.role }}</td>
+                        <td>₹{{ player.base_price }}L</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% else %}
+            <p>No players went unsold in this auction, or data is unavailable.</p>
+        {% endif %}
+
         <hr style="margin-top:30px;">
         <p><a href="{{ url_for('index') }}">Start New Auction (Resets Session)</a></p>
     </div>


### PR DESCRIPTION
Integrates the IPL auction simulation logic into a Flask web application, providing an interactive user interface for team selection, player retention, and participation in the auction.

Key features:
- Team Selection: You can choose your franchise.
- Player Retention:
    - Supports "Any number" and "Exact number" retention modes.
    - You select players to retain for your team.
    - AI teams perform retentions based on the chosen mode.
    - A summary of all retentions is displayed before the auction.
- Interactive Auction:
    - Players are presented one by one.
    - You can bid on players or pass.
    - AI teams simulate bidding against you and each other.
    - Real-time bid logs and auction status are displayed.
- Auction Summary:
    - Displays final team squads, budgets, sold players, and unsold players.
- Backend Logic:
    - Uses an AuctionManager class to handle the auction lifecycle, bidding logic, and state management.
    - Session management is used to maintain game state across requests.
    - Player and team data are loaded from JSON files.